### PR TITLE
implement LRAPA and AQandU corrections, fix style and Cargo.lock package name

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -213,15 +213,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d36492546b6af1463394d46f0c834346f31548646f6ba10849802c9c9a27ac33"
 
 [[package]]
-name = "pm-sensor"
-version = "0.1.0"
-dependencies = [
- "chrono",
- "serialport",
- "structopt",
-]
-
-[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -280,6 +271,15 @@ name = "regex-syntax"
 version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26412eb97c6b088a6997e05f69403a802a92d520de2f8e63c2b65f9e0f47c4e8"
+
+[[package]]
+name = "sds011-reader"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "serialport",
+ "structopt",
+]
 
 [[package]]
 name = "serialport"

--- a/src/main.rs
+++ b/src/main.rs
@@ -45,13 +45,14 @@ fn main() {
         let pm10 = u16::from_le_bytes(buffer[2..4].try_into().unwrap()) as f64 / 10.;
         // CSV output.
         println!(
-            "{},{},{:.3?},{},{:.3?},{:.3?}",
+            "{},{},{:.3?},{},{:.3?},{:.3?},{:.3?}",
             chrono::Local::now().to_rfc3339(),
             pm2_5,
             aqi(PM25_AQI, pm2_5).unwrap_or(501.),
             pm10,
             aqi(PM10_AQI, pm10).unwrap_or(501.),
             aqi(PM25_AQI, lrapa(pm2_5)).unwrap_or(501.),
+            aqi(PM25_AQI, aqandu(pm2_5)).unwrap_or(501.),
         );
     }
 }
@@ -92,7 +93,12 @@ fn aqi(table: &[(f64, f64, f64)], conc: f64) -> Option<f64> {
     None
 }
 
-/// Apply LRAPA correction.
+/// Apply LRAPA correction to the pm2.5 concentration.
 fn lrapa(conc: f64) -> f64 {
     conc * 0.5 - 0.66
+}
+
+/// Apply the AQandU correction to the pm2.5 concentration.
+fn aqandu(conc: f64) -> f64 {
+    conc * 0.778 + 2.65
 }


### PR DESCRIPTION
Feel free to ignore (or just close) this pull request -- I know you made this thing for yourself and I'm just thankful you made the code available.  I made the mistake of running `rustfmt` on the code, which reformatted some stuff.  I consider it gauche to reformat people's code in an unrelated PR and I'm happy to remove this part if you like, but I thought you might not object.

This change implements the LRAPA and AQandU corrections for the AQI number.  The best layperson explanation I've seen is [by the Bold Italic](https://thebolditalic.com/understanding-purpleair-vs-airnow-gov-measurements-of-wood-smoke-pollution-562923a55226).   In summary:

> Empirical studies have found that PurpleAir monitors tend to yield larger AQI values than EPA monitors like those used by AirNow (see end of this article for more on why) when measuring wood smoke. To correct for this, PurpleAir provides two correct factors you can use to get a better estimate...Please note that LRAPA and AQandU are specifically useful as a correction factor for areas where PM 2.5 particles are dominated by wood smoke. You should not use them in other circumstances.

LRAPA is described here:
https://www.lrapa.org/DocumentCenter/View/4147/PurpleAir-Correction-Summary
The data there matches the formula in the PurpleAir tool tip about this.

AQandU is described here:
https://www.aqandu.org/airu_sensor#calibrationSection
There's no formula there.  I implemented the formula from the PurpleAir tool tip about this.

I tested these by hand by taking two raw PM2.5 concentration numbers (60 and 146, basically arbitrarily), using the functions here to calculate the AQI, LRAPA AQI, and AQandU AQI, and comparing them to what PurpleAir reports for the same number.

I added these as two new columns at the end to avoid breaking any CSV reader you already had.